### PR TITLE
Handle direct URLs in open_website

### DIFF
--- a/test_open_website.py
+++ b/test_open_website.py
@@ -1,56 +1,41 @@
-#!/usr/bin/env python3
-"""
-Test script for the new open_website function
-"""
-
 import sys
-import os
+import types
 
-# Add the current directory to Python path to import our modules
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-def test_open_website():
-    """Test the open_website function with various inputs"""
-    try:
-        from tools import open_website
-        print("✅ Successfully imported open_website function")
-        
-        # Test 1: URL detection
-        print("\n🧪 Test 1: URL detection")
-        test_url = "https://www.google.com"
-        result = open_website(test_url)
-        print(f"Input: {test_url}")
-        print(f"Result: {result}")
-        
-        # Test 2: Search query (if sandbox is running)
-        print("\n🧪 Test 2: Search query")
-        test_query = "Python programming"
-        result = open_website(test_query)
-        print(f"Input: {test_query}")
-        print(f"Result: {result}")
-        
-        # Test 3: URL with selector (if sandbox is running)
-        print("\n🧪 Test 3: URL with selector")
-        result = open_website("https://www.google.com", "title")
-        print(f"Input: https://www.google.com with selector 'title'")
-        print(f"Result: {result}")
-        
-        print("\n✅ All tests completed successfully!")
-        
-    except ImportError as e:
-        print(f"❌ Import error: {e}")
-        return False
-    except Exception as e:
-        print(f"❌ Error during testing: {e}")
-        return False
-    
-    return True
+def test_open_website_direct_url(monkeypatch):
+    called = {"search": False, "open": False, "extract": False, "summarize": False}
 
-if __name__ == "__main__":
-    print("🚀 Testing open_website function...")
-    success = test_open_website()
-    if success:
-        print("\n🎉 Test completed successfully!")
-    else:
-        print("\n💥 Test failed!")
-        sys.exit(1)
+    def fake_search_web(query, max_results=3):
+        called["search"] = True
+        return ""
+
+    def fake_open_page(url):
+        called["open"] = True
+
+    def fake_extract_text(selector):
+        called["extract"] = True
+        return "sample text " * 50  # >500 chars
+
+    def fake_summarize(text, max_sentences=5):
+        called["summarize"] = True
+        return "summary"
+
+    fake_search_module = types.SimpleNamespace(search_web=fake_search_web)
+    monkeypatch.setitem(sys.modules, "search", fake_search_module)
+    monkeypatch.setitem(sys.modules, "numpy", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "file_index", types.SimpleNamespace(file_index=None))
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=None))
+
+    import tools
+    monkeypatch.setattr(tools, "open_page_sandbox", fake_open_page)
+    monkeypatch.setattr(tools, "extract_text_sandbox", fake_extract_text)
+    monkeypatch.setattr(tools, "summarize_text", fake_summarize)
+    from tools import open_website
+
+    result = open_website("https://example.com")
+
+    assert result == "summary"
+    assert called["open"]
+    assert called["extract"]
+    assert called["summarize"]
+    assert not called["search"]


### PR DESCRIPTION
## Summary
- Allow `open_website` to treat URL-like queries as direct URLs, bypassing web search and ensuring summarization.
- Add a targeted unit test verifying that direct URL queries are processed and summarized without invoking search.

## Testing
- `pytest test_open_website.py -q`
- `pytest -q` *(fails: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_689262af5c788332b30790ae84ec80e4

Hey there!
Just a quick heads-up: we've linked this PR to its Monday task for you
👉 https://wexlerj1002s-team.monday.com/boards/9914871046/pulses/9914901325
Going forward, you'll need to handle this yourself by including the item ID in the PR title or description. This ensures it connects properly to the task in Monday.
Thanks!
monday dev team 💚